### PR TITLE
Normalize URNs

### DIFF
--- a/src/urn.js
+++ b/src/urn.js
@@ -1,10 +1,35 @@
 "use strict";
 
-function extract(str) {
-    var matches = String(str).match(/\burn:(?!urn:)[a-z0-9][a-z0-9\-]{1,31}:(?:[a-z0-9()+,-.:=@;$_!*\']|%(?:2[1-9a-f]|[3-6][0-9a-f]|7[0-9a-e]))+/ig);
-    if (!matches) { return []; }
+const URN_REGEX = /\burn:((?!urn:)[a-z0-9][a-z0-9\-]{1,31}):((?:[a-z0-9()+,-.:=@;$_!*\']|%(?:2[1-9a-f]|[3-6][0-9a-f]|7[0-9a-e]))+)/ig;
 
-    return matches;
+function scan(str) {
+    return find_matches(str, function(matches) {
+        return matches[0];
+    });
 }
 
-exports.extract = extract;
+function extract(str) {
+    return find_matches(str, function(matches) {
+        return normalize(matches[1], matches[2]);
+    });
+}
+
+function find_matches(str, callback) {
+    str = String(str);
+
+    let matches, urns = [];
+    while((matches = URN_REGEX.exec(str)) !== null) {
+        urns.push(callback(matches));
+    }
+
+    return urns;
+}
+
+function normalize(nid, nss) {
+    nid = nid.toLowerCase();
+    nss = nss.replace(/(%[2-9A-F][A-F])/g, function(m) { return m.toLowerCase(); });
+
+    return "urn:" + nid + ":" + nss;
+}
+
+module.exports = { extract, scan };

--- a/tests/urn.test.js
+++ b/tests/urn.test.js
@@ -2,14 +2,28 @@
 
 const urn = require("../lib/urn");
 
-test("extracts the URNs from a string", () => {
-    var text = "En un pueblo italiano urn:1234:abc al pie de la montaña URN:foo:bar%23.\\";
+describe("scan", () => {
+    test("scans a string for URNs", () => {
+        var text = "En un pueblo italiano urn:1234:abc al pie de la montaña URN:foo:bar%23.\\";
 
-    expect(urn.extract(text)).toEqual(["urn:1234:abc", "URN:foo:bar%23."]);
+        expect(urn.scan(text)).toEqual(["urn:1234:abc", "URN:foo:bar%23."]);
+    });
+
+    test("only extracts URNs with word boundaries at the beginning", () => {
+        var text = "sideburn:mutton:chops";
+
+        expect(urn.scan(text)).toEqual([]);
+    });
 });
 
-test("only extracts URNs with word boundaries at the beginning", () => {
-    var text = "sideburn:mutton:chops";
+describe("extract", () => {
+    test("scans and normalizes URNs", () => {
+        var text = "URN:FOO:BAR urn:foo:%2F1%2F23 urn:foo:%2f1%2f23";
 
-    expect(urn.extract(text)).toEqual([]);
+        expect(urn.extract(text)).toEqual([
+            "urn:foo:BAR",
+            "urn:foo:%2f1%2f23",
+            "urn:foo:%2f1%2f23"
+        ]);
+    });
 });


### PR DESCRIPTION
Follow the same principle of the other identifier libraries (`identifier-doi`, `identifier-repec`, ...) and normalize matches.